### PR TITLE
Actually, Vims everywhere get autosaved

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Otherwise symlink, copy the file, or copy its contents to ~/.tmux.conf
 This adds Vim auto-saving support when running within tmux.
 When any command is run on the command line, be it `ls` or 
 even just hitting ENTER, all Vim sessions running within
-this tmux session will be written.
+all tmux sessions (of this tmux server) will be written.
 
 ### Autosave Installation 
 To enable VIM autosaving, add the following to your .bash\_profile, .bashrc, or .profile:


### PR DESCRIPTION
Unless this changed since I worked on it.  But it looks like
VIM_PANES is still set as a global (-g) server variable.

https://github.com/pivotal/tmux-config/blob/master/plugin/autowrite.vim#L17

Typically, there's only one tmux server running on a machine.
